### PR TITLE
feat: context export create_callback

### DIFF
--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -424,6 +424,29 @@ fn memory_limit_exceeded() {
     );
 }
 
+
+#[test]
+fn test_create_callback() {
+    let context = Context::new().unwrap();
+
+    // Register an object.
+    let mut obj = HashMap::<String, JsValue>::new();
+
+    // insert add function into the object.
+    obj.insert(
+        "add".to_string(),
+        context
+            .create_callback(|a: i32, b: i32| a + b)
+            .unwrap()
+            .into(),
+    );
+    context.set_global("myObj", obj).unwrap();
+
+    let output = context.eval_as::<i32>("myObj.add( 3 , 4 ) ").unwrap();
+
+    assert_eq!(output, 7);
+}
+
 #[test]
 fn context_reset() {
     let c = Context::new().unwrap();


### PR DESCRIPTION
Export create_callback so we can add callback to obj value.

```rust
#[test]
fn test_create_callback() {
    let context = Context::new().unwrap();

    // Register an object.
    let mut obj = HashMap::<String, JsValue>::new();

    // insert add function into the object.
    obj.insert(
        "add".to_string(),
        context
            .create_callback(|a: i32, b: i32| a + b)
            .unwrap()
            .into(),
    );
    context.set_global("myObj", obj).unwrap();

    let output = context.eval_as::<i32>("myObj.add( 3 , 4 ) ").unwrap();

    assert_eq!(output, 7);
}
```